### PR TITLE
Core dep replacement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "alfrasc/laravel-matomo-tracker",
-    "description": "A Laravel facade/wrapper for the piwik/piwik-php-tracker for server side Matomo tracking.",
+    "description": "A Laravel facade/wrapper for the matomo/matomo-php-tracker for server side Matomo tracking.",
     "license": "BSD-3-Clause",
     "authors": [
         {
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/alfrasc/matomotracker",
     "keywords": ["Laravel", "Matomo PHP Tracker", "Piwik", "Piwik PHP Tracker", "server side tracking"],
     "require": {
-        "piwik/piwik-php-tracker": "^1.5"
+        "matomo/matomo-php-tracker": "^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",
@@ -33,10 +33,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Alfrasc\\MatomoTracker\\MatomoTrackerServiceProvider"
+                "Alfrasc\\MatomoTracker\\LaravelMatomoTrackerServiceProvider"
             ],
             "aliases": {
-                "MatomoTracker": "Alfrasc\\MatomoTracker\\Facades\\MatomoTracker"
+                "LaravelMatomoTracker": "Alfrasc\\MatomoTracker\\Facades\\LaravelMatomoTracker"
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# MatomoTracker
+# LaravelMatomoTracker
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Total Downloads][ico-downloads]][link-downloads]
@@ -9,7 +9,7 @@ The `alfrasc\laravel-matomo-tracker` Laravel package is a wrapper for the `piwik
 
 ## Features
 
- * MatomoTracker Facade
+ * LaravelMatomoTracker Facade
  * Queued tracking requests in Laravel queue
 
 Feel free to suggest new features.
@@ -49,7 +49,7 @@ That's it!
 You can use the facade to track.
 
 ``` bash
-MatomoTracker::doTrackPageView('Page Title')
+LaravelMatomoTracker::doTrackPageView('Page Title')
 ```
 
 ### Tracking
@@ -61,29 +61,29 @@ Please see the https://developer.matomo.org/api-reference/PHP-Piwik-Tracker page
 Additionally there are some Methods to simplyfy the usage:
 ``` bash
 // instead of using 
-MatomoTracker::doTrackAction($actionUrl, 'download') // or
-MatomoTracker::doTrackAction($actionUrl, 'link')
+LaravelMatomoTracker::doTrackAction($actionUrl, 'download') // or
+LaravelMatomoTracker::doTrackAction($actionUrl, 'link')
 
 // you can use this
-MatomoTracker::doTrackDownload($actionUrl);
-MatomoTracker::doTrackOutlink($actionUrl);
+LaravelMatomoTracker::doTrackDownload($actionUrl);
+LaravelMatomoTracker::doTrackOutlink($actionUrl);
 ```
 
 #### Queues
 
 For queuing you can use these functions.
 ``` bash
-MatomoTracker::queuePageView(string $documentTitle)
-MatomoTracker::queueEvent(string $category, string $action, $name = false, $value = false)
-MatomoTracker::queueContentImpression(string $contentName, string $contentPiece = 'Unknown', $contentTarget = false)
-MatomoTracker::queueContentInteraction(string $interaction, string $contentName, string $contentPiece = 'Unknown', $contentTarget = false)
-MatomoTracker::queueSiteSearch(string $keyword, string $category = '',  $countResults = false)
-MatomoTracker::queueGoal($idGoal, $revencue = 0.0)
-MatomoTracker::queueDownload(string $actionUrl)
-MatomoTracker::queueOutlink(string $actionUrl)
-MatomoTracker::queueEcommerceCartUpdate(float $grandTotal)
-MatomoTracker::queueEcommerceOrder(float $orderId, float $grandTotal, float $subTotal = 0.0, float $tax = 0.0, float $shipping = 0.0,  float $discount = 0.0)
-MatomoTracker::queueBulkTrack()
+LaravelMatomoTracker::queuePageView(string $documentTitle)
+LaravelMatomoTracker::queueEvent(string $category, string $action, $name = false, $value = false)
+LaravelMatomoTracker::queueContentImpression(string $contentName, string $contentPiece = 'Unknown', $contentTarget = false)
+LaravelMatomoTracker::queueContentInteraction(string $interaction, string $contentName, string $contentPiece = 'Unknown', $contentTarget = false)
+LaravelMatomoTracker::queueSiteSearch(string $keyword, string $category = '',  $countResults = false)
+LaravelMatomoTracker::queueGoal($idGoal, $revencue = 0.0)
+LaravelMatomoTracker::queueDownload(string $actionUrl)
+LaravelMatomoTracker::queueOutlink(string $actionUrl)
+LaravelMatomoTracker::queueEcommerceCartUpdate(float $grandTotal)
+LaravelMatomoTracker::queueEcommerceOrder(float $orderId, float $grandTotal, float $subTotal = 0.0, float $tax = 0.0, float $shipping = 0.0,  float $discount = 0.0)
+LaravelMatomoTracker::queueBulkTrack()
 ```
 
 For setting up queues, find the documentation on https://laravel.com/docs/6.x/queues.
@@ -94,9 +94,9 @@ Have a look in the https://developer.matomo.org/api-reference/PHP-Piwik-Tracker 
 
 Additionaly these settings are available:
 ``` bash
-MatomoTracker::setCustomDimension(int $id, string $value) // only applicable if the custom dimensions plugin is installed on the Matomo installation
-MatomoTracker::setCustomDimensions([]) // array of custom dimension objects {id: <int>, value: <string>} // bulk insert of custom dimensions and basic type checking
-MatomoTracker::setCustomVariables([]) // array of custom variable objects {id: <int>, name: <string>, value: <string>, scope: <string>} // bulk insert of custom variables and basic type checking
+LaravelMatomoTracker::setCustomDimension(int $id, string $value) // only applicable if the custom dimensions plugin is installed on the Matomo installation
+LaravelMatomoTracker::setCustomDimensions([]) // array of custom dimension objects {id: <int>, value: <string>} // bulk insert of custom dimensions and basic type checking
+LaravelMatomoTracker::setCustomVariables([]) // array of custom variable objects {id: <int>, name: <string>, value: <string>, scope: <string>} // bulk insert of custom variables and basic type checking
 ```
 
 ## Change log

--- a/src/Facades/LaravelMatomoTracker.php
+++ b/src/Facades/LaravelMatomoTracker.php
@@ -4,7 +4,7 @@ namespace Alfrasc\MatomoTracker\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class MatomoTracker extends Facade
+class LaravelMatomoTracker extends Facade
 {
     /**
      * Get the registered name of the component.
@@ -13,6 +13,6 @@ class MatomoTracker extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'matomotracker';
+        return 'laravelmatomotracker';
     }
 }

--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -476,4 +476,15 @@ class LaravelMatomoTracker extends MatomoTracker
         })
             ->onQueue($this->queue);
     }
+
+    /**
+     * Called after unserializing (e.g. after popping from the queue). Re-set
+     * self::$URL, as only non-static properties have been applied.
+     */
+    public function __wakeup()
+    {
+        if (!empty($this->apiUrl)) {
+            self::$URL = $this->apiUrl;
+        }
+    }
 }

--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -4,9 +4,9 @@ namespace Alfrasc\MatomoTracker;
 
 use Exception;
 use \Illuminate\Http\Request;
-use PiwikTracker;
+use \MatomoTracker;
 
-class MatomoTracker extends PiwikTracker
+class LaravelMatomoTracker extends MatomoTracker
 {
 
     /** @var string */
@@ -20,7 +20,7 @@ class MatomoTracker extends PiwikTracker
 
     public function __construct(?Request $request, ?int $idSite = null, ?string $apiUrl = null, ?string $tokenAuth = null)
     {
-        $this->tokenAuth = $tokenAuth ?: config('matomotracker.tockenAuth');
+        $this->tokenAuth = $tokenAuth ?: config('matomotracker.tokenAuth');
         $this->queue = config('matomotracker.queue', 'matomotracker');
 
         $this->setTokenAuth(!is_null($tokenAuth) ? $tokenAuth : config('matomotracker.tokenAuth'));
@@ -138,7 +138,7 @@ class MatomoTracker extends PiwikTracker
      *
      * @return $this
      */
-    public function setCustomDimension(int $customDimensionId, string $value)
+    public function setCustomDimension($id, $value)
     {
         $this->setCustomTrackingParameter('dimension' . $customDimensionId, $value);
         return $this;

--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -47,9 +47,16 @@ class LaravelMatomoTracker extends MatomoTracker
         $this->eventCustomVar = false;
         $this->forcedDatetime = false;
         $this->forcedNewVisit = false;
-        $this->generationTime = false;
+        $this->networkTime = false;
+        $this->serverTime = false;
+        $this->transferTime = false;
+        $this->domProcessingTime = false;
+        $this->domCompletionTime = false;
+        $this->onLoadTime = false;
         $this->pageCustomVar = false;
+        $this->ecommerceView = array();
         $this->customParameters = array();
+        $this->customDimensions = array();
         $this->customData = false;
         $this->hasCookies = false;
         $this->token_auth = false;
@@ -96,6 +103,9 @@ class LaravelMatomoTracker extends MatomoTracker
         $this->configCookiesDisabled = false;
         $this->configCookiePath = self::DEFAULT_COOKIE_PATH;
         $this->configCookieDomain = '';
+        $this->configCookieSameSite = '';
+        $this->configCookieSecure = false;
+        $this->configCookieHTTPOnly = false;
 
         $this->currentTs = time();
         $this->createTs = $this->currentTs;

--- a/src/LaravelMatomoTrackerServiceProvider.php
+++ b/src/LaravelMatomoTrackerServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 
-class MatomoTrackerServiceProvider extends ServiceProvider
+class LaravelMatomoTrackerServiceProvider extends ServiceProvider
 {
     /** @var \Illuminate\Http\Request */
     protected $request;
@@ -36,12 +36,12 @@ class MatomoTrackerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../config/matomotracker.php', 'matomotracker');
 
         // Register the service the package provides.
-        $this->app->singleton('matomotracker', function ($app) {
-            return new MatomoTracker(
+        $this->app->singleton('laravelmatomotracker', function ($app) {
+            return new LaravelMatomoTracker(
                 $this->request,
-                Config::get('matomotracker.siteId'),
+                Config::get('matomotracker.idSite'),
                 Config::get('matomotracker.url'),
-                Config::get('matomotracker.tockenAuth')
+                Config::get('matomotracker.tokenAuth')
             );
         });
     }
@@ -53,7 +53,7 @@ class MatomoTrackerServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['matomotracker'];
+        return ['laravelmatomotracker'];
     }
 
     /**


### PR DESCRIPTION
Hey, this pull requests replaces the abandoned `piwik-tracker` with the uptodate `matomo-tracker` (and therefore has to rename the facade). Most of the changes are from @PunchRockgroin, so all the praise should go to him (I've just seen there is no pull request yet, so that's my contribution on this one).