### PR TITLE
Use Laravel request methods to grab the IP address and user agent string.

### DIFF
--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -82,8 +82,8 @@ class LaravelMatomoTracker extends MatomoTracker
         $this->urlReferrer = !empty($request->server('HTTP_REFERER')) ? $request->server('HTTP_REFERER') : false;
         $this->pageCharset = self::DEFAULT_CHARSET_PARAMETER_VALUES;
         $this->pageUrl = self::getCurrentUrl();
-        $this->ip = !empty($request->server('REMOTE_ADDR')) ? $request->server('REMOTE_ADDR') : false;
-        $this->acceptLanguage = !empty($request->server('HTTP_ACCEPT_LANGUAGE')) ? $request->server('HTTP_ACCEPT_LANGUAGE') : false;
+        $this->ip = !empty($request->ip()) ? $request->ip() : false;
+        $this->acceptLanguage = !empty($request->userAgent()) ? $request->userAgent() : false;
         $this->userAgent = !empty($request->server('HTTP_USER_AGENT')) ? $request->server('HTTP_USER_AGENT') : false;
         if (!empty($apiUrl)) {
             self::$URL = $this->apiUrl;

--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -82,9 +82,9 @@ class LaravelMatomoTracker extends MatomoTracker
         $this->urlReferrer = !empty($request->server('HTTP_REFERER')) ? $request->server('HTTP_REFERER') : false;
         $this->pageCharset = self::DEFAULT_CHARSET_PARAMETER_VALUES;
         $this->pageUrl = self::getCurrentUrl();
-        $this->ip = !empty($request->server('REMOTE_ADDR')) ? $request->server('REMOTE_ADDR') : false;
+        $this->ip = !empty($request->ip()) ? $request->ip() : false;
         $this->acceptLanguage = !empty($request->server('HTTP_ACCEPT_LANGUAGE')) ? $request->server('HTTP_ACCEPT_LANGUAGE') : false;
-        $this->userAgent = !empty($request->server('HTTP_USER_AGENT')) ? $request->server('HTTP_USER_AGENT') : false;
+        $this->userAgent = !empty($request->userAgent()) ? $request->userAgent() : false;
         if (!empty($apiUrl)) {
             self::$URL = $this->apiUrl;
         }

--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -82,8 +82,8 @@ class LaravelMatomoTracker extends MatomoTracker
         $this->urlReferrer = !empty($request->server('HTTP_REFERER')) ? $request->server('HTTP_REFERER') : false;
         $this->pageCharset = self::DEFAULT_CHARSET_PARAMETER_VALUES;
         $this->pageUrl = self::getCurrentUrl();
-        $this->ip = !empty($request->ip()) ? $request->ip() : false;
-        $this->acceptLanguage = !empty($request->userAgent()) ? $request->userAgent() : false;
+        $this->ip = !empty($request->server('REMOTE_ADDR')) ? $request->server('REMOTE_ADDR') : false;
+        $this->acceptLanguage = !empty($request->server('HTTP_ACCEPT_LANGUAGE')) ? $request->server('HTTP_ACCEPT_LANGUAGE') : false;
         $this->userAgent = !empty($request->server('HTTP_USER_AGENT')) ? $request->server('HTTP_USER_AGENT') : false;
         if (!empty($apiUrl)) {
             self::$URL = $this->apiUrl;


### PR DESCRIPTION
This pull request fixes issues where `$request->server('REMOTE_ADDR')` may return the wrong IP address.

As an example, in some instances the servers own IP may be returned, or a Cloudflare proxy IP.

To fix this issue, we can use methods in the Illuminate Request object which allow us to grab the correct IP address and user agent string.