### PR TITLE
Fix visibility of $idSite to match parent MatomoTracker class

### DIFF
--- a/src/LaravelMatomoTracker.php
+++ b/src/LaravelMatomoTracker.php
@@ -12,7 +12,7 @@ class LaravelMatomoTracker extends MatomoTracker
     /** @var string */
     protected $apiUrl;
     /** @var int */
-    protected $idSite;
+    public $idSite;
     /** @var string */
     protected $tokenAuth;
     /** @var string */


### PR DESCRIPTION
This PR updates the visibility of the `$idSite` property in the `LaravelMatomoTracker` class from protected to public to comply with PHP inheritance rules.

The parent class `MatomoTracker` declares `$idSite` as public, and having it with a more restrictive visibility in the child class causes a fatal error:

> Access level to Alfrasc\MatomoTracker\LaravelMatomoTracker::$idSite must be public (as in class MatomoTracker)

Making this property public resolves the error and ensures compatibility when extending the MatomoTracker base class.

No other changes were made.
